### PR TITLE
Issue 59

### DIFF
--- a/e2e/specs/application.js
+++ b/e2e/specs/application.js
@@ -35,7 +35,8 @@ const updateApp = (app) => {
     goToApp(app),
     S.click('[href="#application"]'),
     S.fillForm(forms.app, app),
-    S.click('button[type="submit"]')
+    S.click('button[type="submit"]'),
+    S.sleep(1000)
   )
 }
 

--- a/e2e/specs/index.test.js
+++ b/e2e/specs/index.test.js
@@ -72,7 +72,7 @@ describe('LPWAN Server Web Client Integration Tests', () => {
 
     // Remove skip after bug fix
     // Bug:  UI not PUTing applicationNetworkTypeLink after app update
-    describe.skip('Update application', () => {
+    describe('Update application', () => {
       test('Update application description', () => App.app1.update(ctx))
       test('Verify application updated', () => App.app1.verifyUpdate(ctx))
       test('Verify app is on LoRa Server', () => Lora.verifyAppDescription(input.app1Updated)(loraCtx))

--- a/e2e/specs/lora-app-server.js
+++ b/e2e/specs/lora-app-server.js
@@ -39,7 +39,8 @@ const verifyNetworkSync = S.seq(
 )
 
 const verifyAppDescription = app => S.seq(
-  goToApp(app),
+  S.tap(ctx => ctx.driver.get(ctx.url)),
+  S.sleep(3000),
   findDescription(app.description)
 )
 

--- a/e2e/specs/lora-app-server.js
+++ b/e2e/specs/lora-app-server.js
@@ -40,7 +40,6 @@ const verifyNetworkSync = S.seq(
 
 const verifyAppDescription = app => S.seq(
   S.tap(ctx => ctx.driver.get(ctx.url)),
-  S.sleep(3000),
   findDescription(app.description)
 )
 

--- a/src/views/NetworkCustomizations/LoRa/Application.js
+++ b/src/views/NetworkCustomizations/LoRa/Application.js
@@ -159,7 +159,7 @@ class LoRaApplicationNetworkSettings extends Component {
     // Not an onSubmit for the framework, but called from the parent component
     // when the submit happens.  Do what need to be done for this networkType.
     onSubmit = async function( e ) {
-console.log( "Submitting: state = ", this.state );
+    console.log( "Submitting: state = ", this.state );
         var ret = this.props.parentRec.name + " is unchanged.";
 
         // If we aren't submitting custom code, get rid of the fields.
@@ -181,10 +181,10 @@ console.log( "Submitting: state = ", this.state );
                     ret = this.props.name + " is created.";
                 }
                 // ...and we had an old record with a data change: UPDATE
-                else if ( JSON.stringify( this.state.value ) !== this.state.original ) {
+                else {
                     console.log(this.props);
                     var updRec = {
-                        id: this.props.netRec.id,
+                        id: this.state.rec.id,
                         networkSettings: this.state.value
                     };
                     await applicationStore.updateApplicationNetworkType( updRec );


### PR DESCRIPTION
#### What does this PR do?
- Remove conditional so that PUT to applicationNetworkTypeLink always happens on app udpate.
- Add sleep in test to workaround race condition in UI

#### Do you have any concerns with this PR?
When an app is updated in the test, the PUT to applicationNetworkTypeLink doesn't happen.  Adding a short sleep after submitting the application update works around this.  Since the front end needs rewritten anyway, and it only happens in the test, I figured a sleep is fine.

#### How can the reviewer verify this PR? Run e2e tests.
#### Any background context you want to provide? No
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? #59 
- Does the documentation need an update? No
- Does this add new dependencies? No
- Have you added unit or functional tests for this PR? No
